### PR TITLE
Fixed system_dialog function

### DIFF
--- a/timer.py
+++ b/timer.py
@@ -17,7 +17,7 @@ def system_dialog(TIMER_SCRIPT):
     try:
         output = subprocess.check_output(['osascript', TIMER_SCRIPT]).decode('utf-8').strip()
         print("The timer will run for " + output + " minutes.")
-        interval = int(output[0]) * 60
+        interval = int(output) * 60
         pom_timer(interval)
     except subprocess.CalledProcessError as e:
         if e.returncode == 1:


### PR DESCRIPTION
Addresses https://github.com/stephburton/pom_timer/issues/10 to fix the `system_dialog` function in `timer.py`.

#### The bug:

A mistake in the computed value of the `interval` variable within the `system_dialog` function, resulted in the `pom_timer` function running for the incorrect length of time.

The `system_dialog` function is responsible for presenting the user with a dialog (via `timer.scpt`) where they enter the number of minutes the timer should run. This value is then converted to seconds, which is then passed to the `pom_timer` function. The `pom_timer` function then runs the timer itself using the Python time module.

#### The solution:

- I reviewed my code to determine which functions (or AppleScripts) might be involved in the bug.
- I used the `print()` function on the variables involved, to output their values to the terminal.
- Based on the output in the terminal I was able to determine the offending line: `interval = int(output[0]) * 60`
  - The code was specifying `output[0]`. This was interpreted as though `output` was a list and the calculation should be performed using only the item at position `[0]`: this first digit.
  - An example: `25` * 60 = 660 seconds. Instead this was calculated as `2` * 60 = 120 seconds.
- I removed the `[0]` to make the line: `interval = int(output) * 60`
- Now the timer works as expected. 